### PR TITLE
Add Portuguese USB creator script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,37 @@
 # DePaula
-gpt plus
+
+Ferramentas para criar um pendrive bootável com Ubuntu.
+
+## Pré-requisitos
+
+Instale os seguintes pacotes e execute os comandos com privilégios de administrador (use `sudo`):
+
+* `alien` - conversão de formatos de pacote.
+* `dnf` - gerenciador de pacotes usado nos passos de instalação.
+* Direitos de administrador.
+
+## Identificando o dispositivo correto
+
+Antes de gravar a imagem, descubra qual é o pendrive alvo usando `lsblk`:
+
+```bash
+$ lsblk
+NAME   MAJ:MIN RM SIZE RO TYPE MOUNTPOINT
+sda      8:0    0 100G  0 disk
+├─sda1   8:1    0  95G  0 part /
+└─sda2   8:2    0   5G  0 part [SWAP]
+sdb      8:16   1  16G  0 disk
+└─sdb1   8:17   1  16G  0 part /media/usb
+```
+
+No exemplo acima o pendrive é `sdb`. **Todos os dados do dispositivo escolhido serão apagados**, portanto confirme o caminho antes de continuar.
+
+## Uso do script
+
+O repositório contém o script `usb-ubuntu.sh` que procura automaticamente um pendrive de aproximadamente 59GB, 64GB ou 113GB e grava nele a imagem do Ubuntu 24.04.2. Execute:
+
+```bash
+sudo ./usb-ubuntu.sh
+```
+
+Responda `s` quando solicitar confirmação. Após a conclusão, o pendrive estará pronto para boot.

--- a/usb-ubuntu.sh
+++ b/usb-ubuntu.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# Script para criar pendrive bootavel com Ubuntu
+set -e
+ISO_URL="https://releases.ubuntu.com/24.04.2/ubuntu-24.04.2-desktop-amd64.iso?_gl=1*1ir3va3*_gcl_au*MTI3MjE2NDAzOS4xNzQ5MDkyOTQz"
+ISO_PATH="/tmp/ubuntu.iso"
+
+if [ "$EUID" -ne 0 ]; then
+  echo "Este script precisa ser executado como root ou usando sudo." >&2
+  exit 1
+fi
+
+echo "Procurando pendrive de ~59GB, 64GB ou 113GB..."
+DEVICE=$(lsblk -dn -o NAME,SIZE,RM | awk '$3==1 && ($2 ~ /^59G$/ || $2 ~ /^64G$/ || $2 ~ /^113G$/){print $1; exit}')
+
+if [ -z "$DEVICE" ]; then
+  echo "Nenhum dispositivo compativel encontrado." >&2
+  exit 1
+fi
+
+DEV_PATH="/dev/$DEVICE"
+echo "Dispositivo encontrado: $DEV_PATH"
+read -r -p "Todos os dados em $DEV_PATH serao apagados. Continuar? [s/N] " answer
+if [[ "$answer" != "s" && "$answer" != "S" ]]; then
+  echo "Operacao cancelada." >&2
+  exit 1
+fi
+
+umount "${DEV_PATH}"?* 2>/dev/null || true
+
+if [ ! -f "$ISO_PATH" ]; then
+  echo "Baixando imagem do Ubuntu..."
+  curl -L -o "$ISO_PATH" "$ISO_URL"
+fi
+
+echo "Gravando ISO em $DEV_PATH..."
+dd if="$ISO_PATH" of="$DEV_PATH" bs=4M status=progress oflag=sync
+
+echo "Concluido."


### PR DESCRIPTION
## Summary
- translate README to PT-BR and explain how to use the new script
- add `usb-ubuntu.sh` to automatically create a bootable Ubuntu 24.04.2 USB

## Testing
- `shellcheck usb-ubuntu.sh`
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_68410e5f5348832e8361e0e6141033ec